### PR TITLE
Update Transaction.php

### DIFF
--- a/src/Rede/Transaction.php
+++ b/src/Rede/Transaction.php
@@ -490,7 +490,7 @@ class Transaction implements RedeSerializable, RedeUnserializable
      */
     public function setAmount($amount)
     {
-        $this->amount = (int)($amount * 100);
+        $this->amount = (int)$amount;
         return $this;
     }
 


### PR DESCRIPTION
Na documentação da rede informa que o valor deve ser passado como:
10,00 = 1000 / 0,50 = 50

e não como está no exemplo 20.99

Nesta linha ao passar valores quebrados (67,50 / 10,50) multiplicar ele por 100 faz sentido, porque estes dois valores ficam:
67,50 * 100 = 6750 / 10,50 * 100 = 1050

Mas quando passamos valor inteiros (10,00 / 50,00) multiplicar por 100 não faz sentido porque estes valores ficam:
10 * 100 = 1000 / 50 * 100 = 5000
ou se respeitarmos a documentação iríamos enviar
10,00 -> 1000 * 100 = 10000

Ou seja, existe um erro nesta parte quando multiplicamos por 100, o correto é apenas deixar convertendo para o valor inteiro, porque neste caso o usuário deve enviar exatamente como a documentação pede:
10,00 = 1000 / 15,70 = 1570

A única coisa é que o usuário deverá realizar o envio respeitando a documentação, já que deverá enviar também as casas decimais mesmo que elas tenham o valor 0.

Espero ter ajudado e estar correto!!! Se estiver errado peço que me desculpem!!