### PR TITLE
Alterada versao do logger para compatibilidade com o Symfony 4.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "php": ">=5.6",
     "ext-curl": "*",
     "ext-json": "*",
-    "psr/log":"1.0.2"
+    "psr/log":"^1.1"
   },
   "suggest": {
     "monolog/monolog": "Allows more advanced logging of the application flow"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "developersrede/erede-php",
+  "name": "ricktg/erede-php",
   "description": "e.Rede integration SDK",
   "minimum-stability": "stable",
   "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "ricktg/erede-php",
+  "name": "developersrede/erede-php",
   "description": "e.Rede integration SDK",
   "minimum-stability": "stable",
   "license": "MIT",


### PR DESCRIPTION
A dependencia Psr/Log na versao 1.0.2 e imcompativel com Symfony 4 que usa a versao 1.1. Nao houveram problemas em testes integrados.