### PR TITLE
Adiciona exemplo de configuração de parcelamento

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ $transaction = (new \Rede\Transaction(20.99, 'pedido' . time()))->creditCard(
     'John Snow'
 );
 
+// Configuração de parcelamento
+// $transaction->setInstallments(3);
+
 // Autoriza a transação
 $transaction = (new \Rede\eRede($store))->create($transaction);
 


### PR DESCRIPTION
Adiciona um exemplo de configuração do parcelamento no primeiro exemplo de autorização de uma transação, segundo uma resposta na issue #22