### PR TITLE
Erro na função setAmount

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "developersrede/erede-php",
+  "name": "filipeaugusto/erede-php",
   "version": "4.2.1",
   "description": "e.Rede integration SDK",
   "minimum-stability": "stable",
@@ -21,8 +21,8 @@
   },
   "authors": [
     {
-      "name": "João Batista Neto",
-      "email": "neto.joaobatista@gmail.com"
+      "name": "Filipe Augusto Magalhães",
+      "email": "filipeaugustomagalhaes@gmail.com"
     }
   ]
 }

--- a/src/Rede/Transaction.php
+++ b/src/Rede/Transaction.php
@@ -517,7 +517,7 @@ class Transaction implements RedeSerializable, RedeUnserializable
      */
     public function setAmount($amount)
     {
-        $this->amount = (int)($amount * 100);
+        $this->amount = ceil($amount * 100);
         return $this;
     }
 


### PR DESCRIPTION
Olá bom dia.

Estou desenvolvendo uma aplicação em PHP com integração a Rede e encontrei um pequeno problema.

Na classe /vendor/developersrede/erede-php/src/Rede/Transaction.php a função setAmount realiza a seguinte operação (int)($amount * 100);

Essa operação pode retornar alguns valores errados, ex (int) (9.04 * 100) = 903.

Uma sugestão para resolver esse pequeno problema seria alterar:

DE:
public function setAmount($amount)
{
$this->amount = (int)($amount * 100);
return $this;
}
PARA:
public function setAmount($amount)
{
$this->amount = ceil($amount * 100);
return $this;
}