### PR TITLE
Adicionando o campo authorizationCode na classe Brand

### DIFF
--- a/src/Rede/Brand.php
+++ b/src/Rede/Brand.php
@@ -22,6 +22,11 @@ class Brand
     private $returnMessage;
 
     /**
+     * @var string
+     */
+    private $authorizationCode;
+
+    /**
      * @return string
      */
     public function getName(): string
@@ -78,5 +83,15 @@ class Brand
         return $this;
     }
 
+    /**
+     * @param string $authorizationCode
+     *
+     * @return Brand
+     */
+    public function setAuthorizationCode(string $authorizationCode): Brand
+    {
+        $this->authorizationCode = $authorizationCode;
+        return $this;
+    }
 
 }


### PR DESCRIPTION
Seguindo a documentação da REDE, o campo authorizationCode é retornado dentro da propriedade Brand.

Como esse campo não existia na classe, ele não era retornado na transação, causando [esta falha](https://github.com/DevelopersRede/erede-php/issues/52).

Desta maneira o retorno é incluído na propriedade Brand, e pode ser lido na resposta da transação.