### PR TITLE
Adicionando atributo brandTid na classe Brand

### DIFF
--- a/src/Rede/Brand.php
+++ b/src/Rede/Brand.php
@@ -22,6 +22,12 @@ class Brand
     private $returnMessage;
 
     /**
+     * @var string
+     */
+    private $brandTid;
+
+
+    /**
      * @return string
      */
     public function getName(): string
@@ -75,6 +81,25 @@ class Brand
     public function setReturnMessage(string $returnMessage): Brand
     {
         $this->returnMessage = $returnMessage;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBrandTid()
+    {
+        return $this->brandTid;
+    }
+
+    /**
+     * @param mixed $brandTid
+     *
+     * @return Brand
+     */
+    public function setBrandTid(string $brandTid): Brand
+    {
+        $this->brandTid = $brandTid;
         return $this;
     }
 


### PR DESCRIPTION
Seguindo a lógica do método jsonUnserialize em relação ao json de retorno, o qual atribui e popula os atributos da classe Transaction, o atributo brandTid nunca possuia valor atribuido, pois ele no json de retorno ele se encontra dentro do objeto Brand  e esse atributo não existe na classe Brand, somente na Transaction. Acredito ser o mesmo caso do PR #54.
Pensei em remover o atributo da classe Transaction, mas deixei em aberto.