### PR TITLE
Adicionando opção de retornar uma Transaction dentro da RedeException

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,8 @@
   "description": "e.Rede integration SDK",
   "license": "MIT",
   "type": "library",
+  "minimum-stability": "dev",
+  "prefer-stable" : true
   "require": {
     "php": "^8.1",
     "ext-curl": "*",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "pablosanches/erede-php-fork",
   "version": "5.1.3",
   "description": "e.Rede integration SDK",
-  "minimum-stability": "stable",
   "license": "MIT",
   "type": "library",
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "developersrede/erede-php",
+  "name": "pablosanches/erede-php-fork",
   "version": "5.1.3",
   "description": "e.Rede integration SDK",
   "minimum-stability": "stable",

--- a/src/Rede/Exception/RedeException.php
+++ b/src/Rede/Exception/RedeException.php
@@ -3,22 +3,23 @@
 namespace Rede\Exception;
 
 use RuntimeException;
+use Throwable;
 
 class RedeException extends RuntimeException
 {
-    private string $response;
+    private ?string $response = null;
 
     public function __construct(
         string $message = "",
         int $code = 0,
         ?Throwable $previous = null,
-        string $response
+        ?string $response = null
     ) {
         parent::__construct($message, $code, $previous);
         $this->response = $response;
     }
 
-    public function getResponse(): string
+    public function getResponse(): ?string
     {
         return $this->response;
     }

--- a/src/Rede/Exception/RedeException.php
+++ b/src/Rede/Exception/RedeException.php
@@ -2,25 +2,26 @@
 
 namespace Rede\Exception;
 
+use Rede\Transaction;
 use RuntimeException;
 use Throwable;
 
 class RedeException extends RuntimeException
 {
-    private ?string $response = null;
+    private ?Transaction $transaction = null;
 
     public function __construct(
         string $message = "",
         int $code = 0,
         ?Throwable $previous = null,
-        ?string $response = null
+        ?Transaction $transaction = null
     ) {
         parent::__construct($message, $code, $previous);
-        $this->response = $response;
+        $this->transaction = $transaction;
     }
 
-    public function getResponse(): ?string
+    public function getTransaction(): ?Transaction
     {
-        return $this->response;
+        return $this->transaction;
     }
 }

--- a/src/Rede/Exception/RedeException.php
+++ b/src/Rede/Exception/RedeException.php
@@ -6,4 +6,20 @@ use RuntimeException;
 
 class RedeException extends RuntimeException
 {
+    private string $response;
+
+    public function __construct(
+        string $message = "",
+        int $code = 0,
+        ?Throwable $previous = null,
+        string $response
+    ) {
+        parent::__construct($message, $code, $previous);
+        $this->response = $response;
+    }
+
+    public function getResponse(): string
+    {
+        return $this->response;
+    }
 }

--- a/src/Rede/Service/AbstractTransactionsService.php
+++ b/src/Rede/Service/AbstractTransactionsService.php
@@ -108,7 +108,8 @@ abstract class AbstractTransactionsService extends AbstractService
             throw new RedeException(
                 $this->transaction->getReturnMessage() ?? 'Error on getting the content from the API',
                 (int)$this->transaction->getReturnCode(),
-                $previous
+                $previous,
+                $this->transaction
             );
         }
 

--- a/src/Rede/Transaction.php
+++ b/src/Rede/Transaction.php
@@ -382,7 +382,7 @@ class Transaction implements RedeSerializable, RedeUnserializable
                 'additional' => $this->additional
             ],
             function ($value) {
-                return !is_null($value);
+                return !empty($value);
             }
         );
     }


### PR DESCRIPTION
## Problema:
Quando uma transação é negada, não é possível recuperar o tid da transação dentro da exception.

## Solução:
Adicionando o método getTransaction dentro da RedeException.