### PR TITLE
Transaction.php

### DIFF
--- a/src/Rede/Transaction.php
+++ b/src/Rede/Transaction.php
@@ -382,7 +382,7 @@ class Transaction implements RedeSerializable, RedeUnserializable
                 'additional' => $this->additional
             ],
             function ($value) {
-                return !is_null($value);
+                return !empty($value);
             }
         );
     }


### PR DESCRIPTION
jsonSerialize - array filter changed from !is_null to !empty.
Property urls always return with empty array is throws an error _Urls: Required parameter missing (kind)._