### PR TITLE
Fixed code highlighting issue on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ fazer:
 docker build . -t erede-docker
 docker run -e REDE_PV='1234' -e REDE_TOKEN='5678' erede-docker
 ```
-````
+
 Caso necessário, o SDK possui a possibilidade de logs de depuração que podem ser utilizados ao executar os testes. Para isso, 
 basta exportar a variável de ambiente `REDE_DEBUG` com o valor 1:
 


### PR DESCRIPTION
Just fixed the code highlight, so the examples are clearer to understand instead of plain text. I was having a hard time reading the docs, I hope this helps someone else too!