### PR TITLE
feat: Migra a autenticação do SDK de Basic Auth para OAuth2 (#76)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-  "name": "developersrede/erede-php",
-  "version": "5.2.1",
+  "name": "robsondrs/erede-php",
+  "version": "5.2.5",
   "description": "e.Rede integration SDK",
   "minimum-stability": "stable",
   "license": "MIT",
@@ -28,6 +28,10 @@
     {
       "name": "João Batista Neto",
       "email": "neto.joaobatista@gmail.com"
+    },
+    {
+      "name": "Robson Soares",
+      "email": "robson_drs@hotmail.com"
     }
   ]
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "library",
   "require": {
-    "php": "^8.1",
+    "php": "^7.3",
     "ext-curl": "*",
     "ext-json": "*",
     "psr/log": "*",

--- a/src/Rede/Environment.php
+++ b/src/Rede/Environment.php
@@ -11,6 +11,12 @@ class Environment implements RedeSerializable
     public const VERSION = 'v1';
 
     /**
+     * OAuth2 token endpoints
+     */
+    public const OAUTH_TOKEN_PRODUCTION = 'https://api.userede.com.br/redelabs/oauth2/token';
+    public const OAUTH_TOKEN_SANDBOX = 'https://rl7-sandbox-api.useredecloud.com.br/oauth2/token';
+
+    /**
      * @var string|null
      */
     private ?string $ip = null;
@@ -26,6 +32,11 @@ class Environment implements RedeSerializable
     private string $endpoint;
 
     /**
+     * @var string OAuth2 token endpoint URL
+     */
+    private string $oauthTokenUrl;
+
+    /**
      * Creates an environment with its base url and version
      *
      * @param string $baseUrl
@@ -33,6 +44,14 @@ class Environment implements RedeSerializable
     private function __construct(string $baseUrl)
     {
         $this->endpoint = sprintf('%s/%s/', $baseUrl, Environment::VERSION);
+
+        if ($baseUrl === Environment::PRODUCTION) {
+            $this->oauthTokenUrl = Environment::OAUTH_TOKEN_PRODUCTION;
+        } elseif ($baseUrl === Environment::SANDBOX) {
+            $this->oauthTokenUrl = Environment::OAUTH_TOKEN_SANDBOX;
+        } else {
+            $this->oauthTokenUrl = rtrim($baseUrl, '/') . '/oauth2/token';
+        }
     }
 
     /**
@@ -59,6 +78,24 @@ class Environment implements RedeSerializable
     public function getEndpoint(string $service): string
     {
         return $this->endpoint . $service;
+    }
+
+    /**
+     * @return string OAuth2 token endpoint URL
+     */
+    public function getOAuthTokenUrl(): string
+    {
+        return $this->oauthTokenUrl;
+    }
+
+    /**
+     * @param string $oauthTokenUrl
+     * @return $this
+     */
+    public function setOAuthTokenUrl(string $oauthTokenUrl): static
+    {
+        $this->oauthTokenUrl = $oauthTokenUrl;
+        return $this;
     }
 
     /**

--- a/src/Rede/Store.php
+++ b/src/Rede/Store.php
@@ -11,6 +11,16 @@ class Store
     private Environment $environment;
 
     /**
+     * @var string|null Bearer token obtained via OAuth2
+     */
+    private ?string $bearerToken = null;
+
+    /**
+     * @var int|null Epoch expiration of the token
+     */
+    private ?int $bearerTokenExpiresAt = null;
+
+    /**
      * Creates a store.
      *
      * @param string           $filiation
@@ -77,5 +87,35 @@ class Store
     {
         $this->token = $token;
         return $this;
+    }
+
+    /**
+     * Define the bearer token and the absolute expiration time (epoch).
+     *
+     * @param string $token
+     * @param int    $expiresAtEpoch
+     * @return $this
+     */
+    public function setBearerToken(string $token, int $expiresAtEpoch): static
+    {
+        $this->bearerToken = $token;
+        $this->bearerTokenExpiresAt = $expiresAtEpoch;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getBearerToken(): ?string
+    {
+        return $this->bearerToken;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getBearerTokenExpiresAt(): ?int
+    {
+        return $this->bearerTokenExpiresAt;
     }
 }


### PR DESCRIPTION
## Descrição
Migra a autenticação do SDK de Basic Auth para OAuth2 conforme nova documentação da e.Rede.

## Alterações
- ✅ Adiciona constantes de endpoints OAuth2 em `Environment`
- ✅ Implementa cache de Bearer token em `Store`
- ✅ Substitui `CURLOPT_USERPWD` por `Authorization: Bearer` em `AbstractService`
- ✅ Adiciona obtenção automática de token via client_credentials

## Testes
- [x] Testes existentes passam (após ajuste de credenciais)
- [x] OAuth2 flow implementado e testado

Fixes #76 